### PR TITLE
Show distance, duration expectation and recurrent ATMs 

### DIFF
--- a/brain/src/components/scheduler/BrainMap.tsx
+++ b/brain/src/components/scheduler/BrainMap.tsx
@@ -19,6 +19,7 @@ interface MapProps {
         lat: number;
         lng: number;
       };
+      reincident: boolean;
     };
     start_date: string;
     engineer?: number;

--- a/brain/src/components/scheduler/BrainMap.tsx
+++ b/brain/src/components/scheduler/BrainMap.tsx
@@ -19,7 +19,7 @@ interface MapProps {
         lat: number;
         lng: number;
       };
-      reincident: boolean;
+      recurrent: boolean;
     };
     start_date: string;
     engineer?: number;

--- a/brain/src/components/scheduler/ExtraInfoATM.tsx
+++ b/brain/src/components/scheduler/ExtraInfoATM.tsx
@@ -15,7 +15,7 @@ interface ExtraInfoATMProps {
       service: string;
       region: string,
       service_time: string,
-      reincident: boolean;
+      recurrent: boolean;
       coor: {
         lat: number;
         lng: number;

--- a/brain/src/components/scheduler/ExtraInfoATM.tsx
+++ b/brain/src/components/scheduler/ExtraInfoATM.tsx
@@ -15,6 +15,7 @@ interface ExtraInfoATMProps {
       service: string;
       region: string,
       service_time: string,
+      reincident: boolean;
       coor: {
         lat: number;
         lng: number;

--- a/brain/src/components/scheduler/ExtraInfoChangeEngineer.tsx
+++ b/brain/src/components/scheduler/ExtraInfoChangeEngineer.tsx
@@ -1,32 +1,34 @@
 import React, { Component } from "react";
+
 import Card from "react-bootstrap/Card";
 import Table from "react-bootstrap/Table";
 import Badge from "react-bootstrap/Badge";
 
 interface Ticket {
-    _id: string;
-    atm: ATM
-    start_date: string;
-    engineer?: number;
-  }
+  _id: string;
+  atm: ATM;
+  start_date: string;
+  engineer?: number;
+}
 
 interface ATM {
-      _id: string;
-      address: string;
-      suburb: string;
-      postal_code: number;
-      city: string;
-      state: string;
-      brand: string;
-      model: string;
-      service: string;
-      region: string,
-      service_time: string,
-      coor: {
-        lat: number;
-        lng: number;
-      };
-    };
+  _id: string;
+  address: string;
+  suburb: string;
+  postal_code: number;
+  city: string;
+  state: string;
+  brand: string;
+  model: string;
+  service: string;
+  region: string;
+  service_time: string;
+  reincident: boolean;
+  coor: {
+    lat: number;
+    lng: number;
+  };
+}
 
 interface Engineer {
   name: string;
@@ -40,19 +42,42 @@ interface Engineer {
   manager: string;
 }
 interface ExtraInfoChangeEngineerProps {
-    ticket: Ticket;
+  ticket: Ticket;
 }
 
-const COLUMN_NAMES = ["Nombre", "Conveniencia"]
+const COLUMN_NAMES = [
+  "Nombre",
+  "Conveniencia",
+  "Tiempo de Llegada",
+  "Distancia",
+];
 
-export class ExtraInfoChangeEngineer extends Component<ExtraInfoChangeEngineerProps> {
+export class ExtraInfoChangeEngineer extends Component<
+  ExtraInfoChangeEngineerProps
+> {
   engineersRecommended: Engineer[];
-  constructor(props: ExtraInfoChangeEngineerProps){
-    super(props)
-
-    this.engineersRecommended = this.getEngineersRecommended(this.props.ticket)
-
+  state: any;
+  constructor(props: ExtraInfoChangeEngineerProps) {
+    super(props);
+    this.engineersRecommended = this.getEngineersRecommended(this.props.ticket);
+    this.state = this.initState();
+    console.log(this.engineersRecommended);
+    console.log(this.state);
+    this.engineersRecommended.forEach(eng => {
+      this.getDistance(eng._id, this.props.ticket.atm.coor, eng.coor);
+    })
   }
+
+  initState = () => {
+    let st: any = {};
+    this.engineersRecommended.forEach((eng) => {
+      st[eng._id] = {
+        time: 0,
+        distance: 0,
+      };
+    });
+    return st;
+  };
   // This should be a request to ML server.
   getEngineersRecommended = (ticket: Ticket) => {
     console.log(ticket.atm._id);
@@ -89,6 +114,31 @@ export class ExtraInfoChangeEngineer extends Component<ExtraInfoChangeEngineerPr
     ];
     return engineers;
   };
+  // This will be added in the backend and the distance result will be part of tthe recomendation
+  getDistance = (eng: number, origin: any, dest: any) => {
+    const DistanceMatrixService = new google.maps.DistanceMatrixService();
+    DistanceMatrixService.getDistanceMatrix(
+      {
+        origins: [origin],
+        destinations: [dest],
+        travelMode: google.maps.TravelMode.DRIVING,
+      },
+      (res, status) => {
+        if (status !== google.maps.DistanceMatrixStatus.OK) {
+          alert("Error was: " + status);
+        } else {
+          console.log(res);
+          let state: any = {};
+          state[eng] = {
+            time: res.rows[0].elements[0].duration.text,
+            distance: res.rows[0].elements[0].distance.text,
+          };
+          this.setState(state);
+        }
+      }
+    );
+  };
+
   render() {
     return (
       <div className="p-1">
@@ -99,20 +149,50 @@ export class ExtraInfoChangeEngineer extends Component<ExtraInfoChangeEngineerPr
               <thead>
                 <tr>
                   {COLUMN_NAMES.map((column) => (
-                    <th>{column}</th>
+                    <th key={`column_${column}`}>{column}</th>
                   ))}
                 </tr>
               </thead>
               <tbody>
                 {this.engineersRecommended.map((engineer) => (
-                  <tr>
-                    <td onDoubleClick={() => window.alert("double")}>{engineer.name}</td>
+                  <tr key={`row_${engineer._id}`}>
+                    <td onDoubleClick={() => window.alert("double")}>
+                      {engineer.name}
+                    </td>
                     <td>
                       {
                         <Badge variant={true ? "warning" : "danger"}>
                           0.65
                         </Badge>
                       }
+                    </td>
+                    <td>
+                      <span
+                        key={engineer._id}
+                        onClick={() =>
+                          this.getDistance(
+                            engineer._id,
+                            this.props.ticket.atm.coor,
+                            engineer.coor
+                          )
+                        }
+                      >
+                        {this.state[engineer._id].time}
+                      </span>
+                    </td>
+                    <td>
+                      <span
+                        key={engineer._id}
+                        onClick={() =>
+                          this.getDistance(
+                            engineer._id,
+                            this.props.ticket.atm.coor,
+                            engineer.coor
+                          )
+                        }
+                      >
+                        {this.state[engineer._id].distance}
+                      </span>
                     </td>
                   </tr>
                 ))}

--- a/brain/src/components/scheduler/ExtraInfoChangeEngineer.tsx
+++ b/brain/src/components/scheduler/ExtraInfoChangeEngineer.tsx
@@ -23,7 +23,7 @@ interface ATM {
   service: string;
   region: string;
   service_time: string;
-  reincident: boolean;
+  recurrent: boolean;
   coor: {
     lat: number;
     lng: number;

--- a/brain/src/components/scheduler/ExtraInfoRow.tsx
+++ b/brain/src/components/scheduler/ExtraInfoRow.tsx
@@ -19,6 +19,7 @@ interface Ticket {
       service: string;
       region: string,
       service_time: string,
+      reincident: boolean;
       coor: {
         lat: number;
         lng: number;

--- a/brain/src/components/scheduler/ExtraInfoRow.tsx
+++ b/brain/src/components/scheduler/ExtraInfoRow.tsx
@@ -19,7 +19,7 @@ interface Ticket {
       service: string;
       region: string,
       service_time: string,
-      reincident: boolean;
+      recurrent: boolean;
       coor: {
         lat: number;
         lng: number;

--- a/brain/src/components/scheduler/Scheduler.tsx
+++ b/brain/src/components/scheduler/Scheduler.tsx
@@ -29,7 +29,7 @@ interface Ticket {
     service: string;
     region: string;
     service_time: string;
-    reincident: boolean;
+    recurrent: boolean;
     coor: {
       lat: number;
       lng: number;
@@ -65,7 +65,7 @@ class Scheduler extends Component {
           model: "NEXTGEN 3700",
           region: "METRO NORTE",
           service_time: "L-V 09:00-16:00",
-          reincident: false,
+          recurrent: false,
           coor: {
             lat: 19.5682414,
             lng: -99.0436029,
@@ -89,7 +89,7 @@ class Scheduler extends Component {
           model: "NEXTGEN 3700",
           region: "METRO NORTE",
           service_time: "L-V 09:00-16:00",
-          reincident: true,
+          recurrent: true,
           coor: {
             lat: 19.5092414,
             lng: -99.0836029,

--- a/brain/src/components/scheduler/Scheduler.tsx
+++ b/brain/src/components/scheduler/Scheduler.tsx
@@ -8,40 +8,40 @@ import BrainMap from "./BrainMap";
 import TicketSchedulerTable from "./SchedulerTicketTable";
 import "./Scheduler.css";
 
-
 interface SchedulerState {
   tickets: Ticket[] | [];
   ticketsShowedOnMap: {
-      [key: string]: boolean;
+    [key: string]: boolean;
   };
 }
 
 interface Ticket {
+  _id: string;
+  atm: {
     _id: string;
-    atm: {
-      _id: string;
-      address: string;
-      suburb: string;
-      postal_code: number;
-      city: string;
-      state: string;
-      brand: string;
-      model: string;
-      service: string;
-      region: string,
-      service_time: string,
-      coor: {
-        lat: number;
-        lng: number;
-      };
+    address: string;
+    suburb: string;
+    postal_code: number;
+    city: string;
+    state: string;
+    brand: string;
+    model: string;
+    service: string;
+    region: string;
+    service_time: string;
+    reincident: boolean;
+    coor: {
+      lat: number;
+      lng: number;
     };
-    start_date: string;
-    engineer?: number;
-  }
+  };
+  start_date: string;
+  engineer?: number;
+}
 
 type showOnMap = {
-  [key:string]: boolean;
-}
+  [key: string]: boolean;
+};
 
 class Scheduler extends Component {
   private tickets: Ticket[];
@@ -65,6 +65,7 @@ class Scheduler extends Component {
           model: "NEXTGEN 3700",
           region: "METRO NORTE",
           service_time: "L-V 09:00-16:00",
+          reincident: false,
           coor: {
             lat: 19.5682414,
             lng: -99.0436029,
@@ -88,9 +89,10 @@ class Scheduler extends Component {
           model: "NEXTGEN 3700",
           region: "METRO NORTE",
           service_time: "L-V 09:00-16:00",
+          reincident: true,
           coor: {
-            lat: 19.5692414,
-            lng: -99.0436029,
+            lat: 19.5092414,
+            lng: -99.0836029,
           },
         },
         start_date: "25/04/2020 11:42",
@@ -102,8 +104,8 @@ class Scheduler extends Component {
         name: "CALVILLO FLORIANO JOSE DE JESUS",
         _id: 1730276,
         coor: {
-          lat: 19.7682414,
-          lng: -99.0436029,
+          lat: 19.5292414,
+          lng: -99.0611029,
         },
         region: "NORTE",
         sub_region: "NOROESTE",
@@ -142,8 +144,8 @@ class Scheduler extends Component {
   }
 
   handleTicketsShowedOnMapState(ticketsShowedOnMap: showOnMap) {
-    console.log(ticketsShowedOnMap)
-    this.setState({ticketsShowedOnMap})
+    console.log(ticketsShowedOnMap);
+    this.setState({ ticketsShowedOnMap });
   }
 
   render() {
@@ -159,7 +161,9 @@ class Scheduler extends Component {
                   engineers={this.engineers}
                   actions={["change", "cancel", "displayOnMap"]}
                   ticketsShowedOnMap={this.state.ticketsShowedOnMap}
-                  handleTicketsShowedOnMapState={this.handleTicketsShowedOnMapState.bind(this)}
+                  handleTicketsShowedOnMapState={this.handleTicketsShowedOnMapState.bind(
+                    this
+                  )}
                 />
               </Card.Body>
             </Card>
@@ -172,7 +176,9 @@ class Scheduler extends Component {
                   engineers={this.engineers}
                   actions={["assign", "change", "cancel", "displayOnMap"]}
                   ticketsShowedOnMap={this.state.ticketsShowedOnMap}
-                  handleTicketsShowedOnMapState={this.handleTicketsShowedOnMapState.bind(this)}
+                  handleTicketsShowedOnMapState={this.handleTicketsShowedOnMapState.bind(
+                    this
+                  )}
                 />
               </Card.Body>
             </Card>

--- a/brain/src/components/scheduler/SchedulerTicketTable.tsx
+++ b/brain/src/components/scheduler/SchedulerTicketTable.tsx
@@ -111,21 +111,21 @@ class TicketSchedulerTable extends Component<
   }
 
   // Delete from the DB
-  private handleTicketAssign = async (e: any) => {
-    console.log(e);
+  private handleTicketAssign = async (e: any, index:number) => {
+    console.log(e, index);
   };
   // Delete from the DB
-  private handleTicketCancelation = async (e: any) => {
-    console.log(e);
+  private handleTicketCancelation = async (e: any, index:number) => {
+    console.log(e, index);
   };
   // Delete from the DB
-  private handleEnginnerChange = async (e: any) => {
-    this.displayExtraInfoHandler(this.INVOKERS["CHANGE"], 0);
-    console.log(e);
+  private handleEnginnerChange = async (e: any, index:number) => {
+    this.displayExtraInfoHandler(this.INVOKERS["CHANGE"], index);
+    console.log(e, index);
   };
   // Delete from the DB
-  private handleDisplayOnMap = async (ticketId: string) => {
-    console.log(ticketId)
+  private handleDisplayOnMap = async (ticketId: string, index:number) => {
+    console.log(ticketId, index)
     let ticketsShowedOnMap: showOnMap = { ...this.props.ticketsShowedOnMap };
     ticketsShowedOnMap[ticketId] = !ticketsShowedOnMap[ticketId]
     this.props.handleTicketsShowedOnMapState(ticketsShowedOnMap);
@@ -262,7 +262,7 @@ class TicketSchedulerTable extends Component<
                 }}
               >
                 <span
-                  onClick={() => this.ACTIONS[action].handler(ticket._id)}
+                  onClick={() => this.ACTIONS[action].handler(ticket._id, index)}
                   className="active p-1"
                 >
                   {action === "displayOnMap"

--- a/brain/src/components/scheduler/SchedulerTicketTable.tsx
+++ b/brain/src/components/scheduler/SchedulerTicketTable.tsx
@@ -23,7 +23,7 @@ interface TicketSchedulerTableProps {
       service: string;
       region: string,
       service_time: string,
-      reincident: boolean;
+      recurrent: boolean;
       coor: {
         lat: number;
         lng: number;
@@ -233,10 +233,10 @@ class TicketSchedulerTable extends Component<
                 this.displayExtraInfoHandler(this.INVOKERS["ATM"], index)
               }
             >
-              {ticket.atm.reincident && (
+              {ticket.atm.recurrent && (
                 <Badge variant={"danger"}>{ticket.atm._id}</Badge>
               )}
-              {!ticket.atm.reincident && ticket.atm._id}
+              {!ticket.atm.recurrent && ticket.atm._id}
             </div>
           </td>
         );

--- a/brain/src/components/scheduler/SchedulerTicketTable.tsx
+++ b/brain/src/components/scheduler/SchedulerTicketTable.tsx
@@ -23,6 +23,7 @@ interface TicketSchedulerTableProps {
       service: string;
       region: string,
       service_time: string,
+      reincident: boolean;
       coor: {
         lat: number;
         lng: number;
@@ -232,8 +233,10 @@ class TicketSchedulerTable extends Component<
                 this.displayExtraInfoHandler(this.INVOKERS["ATM"], index)
               }
             >
-              {" "}
-              {ticket.atm._id}
+              {ticket.atm.reincident && (
+                <Badge variant={"danger"}>{ticket.atm._id}</Badge>
+              )}
+              {!ticket.atm.reincident && ticket.atm._id}
             </div>
           </td>
         );


### PR DESCRIPTION
This PR uses the Googe Distance Matrix Service to get the current distance between an engineer and the ticket's ATM, but this should be refactored in order to get the same data from the backend. Also, a property `recurrent` was added to show when an ATM has had failures in the last 30 days if that is the case the ATM ID is highlighted using a red badge.

![image](https://user-images.githubusercontent.com/46686088/81831744-58793380-9503-11ea-89c2-38339aa1193c.png)
